### PR TITLE
Add Wikipedia/Wikidata plant scraper with wiki_species_info table

### DIFF
--- a/app/Stikl.Tests/FakeHttpMessageHandler.cs
+++ b/app/Stikl.Tests/FakeHttpMessageHandler.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using System.Text;
+
+namespace Stikl.Tests;
+
+/// <summary>
+/// A test double for HttpMessageHandler that matches requests by URL predicate
+/// and returns pre-configured JSON responses. Unmatched requests return 404.
+/// </summary>
+public class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly List<(Func<string, bool> Match, string Json)> _rules = [];
+
+    public int CallCount { get; private set; }
+
+    public FakeHttpMessageHandler Add(Func<string, bool> match, string json)
+    {
+        _rules.Add((match, json));
+        return this;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        CallCount++;
+        var url = request.RequestUri?.ToString() ?? "";
+        foreach (var (match, json) in _rules)
+        {
+            if (match(url))
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                    }
+                );
+        }
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+}

--- a/app/Stikl.Tests/Integration/IntegrationTestSetup.cs
+++ b/app/Stikl.Tests/Integration/IntegrationTestSetup.cs
@@ -44,6 +44,42 @@ public class IntegrationTestSetup
           kind      TEXT    NOT NULL,
           payload   TEXT    NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS perenual_species (
+          perenual_id     INTEGER PRIMARY KEY NOT NULL,
+          common_name     TEXT    NOT NULL,
+          scientific_name TEXT[]  NOT NULL,
+          other_name      TEXT[]  NOT NULL,
+          family          TEXT    NULL,
+          cultivar        TEXT    NULL,
+          variety         TEXT    NULL,
+          species_epithet TEXT    NULL,
+          genus           TEXT    NULL,
+          subspecies      TEXT    NULL,
+          img_regular_url TEXT    NULL,
+          img_small_url   TEXT    NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS wiki_species_info (
+          perenual_id              INTEGER NOT NULL REFERENCES perenual_species(perenual_id),
+          lang                     TEXT    NOT NULL,
+          wikipedia_title          TEXT    NULL,
+          wikipedia_page_url       TEXT    NULL,
+          wikipedia_page_id        INTEGER NULL,
+          wikidata_id              TEXT    NULL,
+          description              TEXT    NULL,
+          extract                  TEXT    NULL,
+          common_name              TEXT    NULL,
+          edible                   BOOLEAN NULL,
+          hardiness_zones          TEXT    NULL,
+          conservation_status      TEXT    NULL,
+          taxon_rank               TEXT    NULL,
+          gbif_taxon_id            TEXT    NULL,
+          parent_taxon_name        TEXT    NULL,
+          parent_taxon_wikidata_id TEXT    NULL,
+          scraped_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          PRIMARY KEY (perenual_id, lang)
+        );
         """;
 
     static PostgreSqlContainer? _container;

--- a/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
+++ b/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
@@ -389,34 +389,32 @@ public class WikipediaScraperTests
         }
     }
 
-    // Calls the real Wikipedia and Wikidata APIs — requires network access
+    // Calls the real Wikipedia and Wikidata APIs — requires network access.
+    // Validates the DTOs returned by FetchSpeciesRows without touching the database.
     [TestFixture]
     public class AbiesConcolorLiveApi : WikipediaScraperTests
     {
         [Test]
         public async Task ScrapesAbiesConcolor_PopulatesBothEnglishAndDanish()
         {
-            await InsertSpecies(1, "White Fir", "Abies concolor");
-
             var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(
                 "Stikl/1.0 (integration test; https://github.com/c0dk/stikl)"
             );
             var scraper = new WikipediaScraper(_conn, httpClient, Log.Logger);
-            await scraper.Scrape();
+            var rows = await scraper.FetchSpeciesRows("Abies concolor");
 
-            var enRow = await GetWikiRow(1, "en");
-            var daRow = await GetWikiRow(1, "da");
+            var en = rows.FirstOrDefault(r => r.Lang == "en");
+            var da = rows.FirstOrDefault(r => r.Lang == "da");
 
-            Assert.That(enRow, Is.Not.Null);
-            Assert.That(enRow!.WikipediaTitle, Is.Not.Null.And.Not.Empty);
-            Assert.That(enRow.Description, Is.Not.Null.And.Not.Empty);
-            Assert.That(enRow.WikidataId, Is.Not.Null.And.Not.Empty);
+            Assert.That(en, Is.Not.Null);
+            Assert.That(en!.WikipediaTitle, Is.Not.Null.And.Not.Empty);
+            Assert.That(en.Description, Is.Not.Null.And.Not.Empty);
+            Assert.That(en.WikidataId, Is.Not.Null.And.Not.Empty);
 
             // da.wikipedia.org/wiki/Hvidgran exists for Abies concolor
-            Assert.That(daRow, Is.Not.Null);
-            Assert.That(daRow!.WikipediaTitle, Is.Not.Null.And.Not.Empty);
-            Assert.That(daRow.Description, Is.Not.Null.And.Not.Empty);
+            Assert.That(da, Is.Not.Null);
+            Assert.That(da!.WikipediaTitle, Is.Not.Null.And.Not.Empty);
         }
     }
 }

--- a/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
+++ b/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
@@ -1,0 +1,393 @@
+using System.Net;
+using System.Text;
+using Npgsql;
+using NUnit.Framework;
+using Serilog;
+using Stikl.Web.Data;
+
+namespace Stikl.Tests.Integration;
+
+[Category("Integration")]
+public class WikipediaScraperTests
+{
+    NpgsqlConnection _conn = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _conn = new NpgsqlConnection(IntegrationTestSetup.ConnectionString);
+        await _conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand("TRUNCATE perenual_species CASCADE", _conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [TearDown]
+    public async Task TearDown() => await _conn.DisposeAsync();
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private async Task InsertSpecies(int id, string commonName, params string[] scientificNames)
+    {
+        await using var cmd = new NpgsqlCommand(
+            "INSERT INTO perenual_species(perenual_id, common_name, scientific_name, other_name) VALUES($1, $2, $3, $4)",
+            _conn
+        );
+        cmd.Parameters.AddWithValue(id);
+        cmd.Parameters.AddWithValue(commonName);
+        cmd.Parameters.AddWithValue(scientificNames);
+        cmd.Parameters.AddWithValue(Array.Empty<string>());
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<WikiRow?> GetWikiRow(int perenualId, string lang)
+    {
+        await using var cmd = new NpgsqlCommand(
+            """
+            SELECT wikipedia_title, wikipedia_page_url, wikipedia_page_id, wikidata_id,
+                   description, extract, common_name, edible, hardiness_zones,
+                   conservation_status, taxon_rank, gbif_taxon_id,
+                   parent_taxon_name, parent_taxon_wikidata_id
+            FROM wiki_species_info
+            WHERE perenual_id = $1 AND lang = $2
+            """,
+            _conn
+        );
+        cmd.Parameters.AddWithValue(perenualId);
+        cmd.Parameters.AddWithValue(lang);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+            return null;
+
+        return new WikiRow(
+            WikipediaTitle: reader.IsDBNull(0) ? null : reader.GetString(0),
+            WikipediaPageUrl: reader.IsDBNull(1) ? null : reader.GetString(1),
+            WikipediaPageId: reader.IsDBNull(2) ? null : reader.GetInt32(2),
+            WikidataId: reader.IsDBNull(3) ? null : reader.GetString(3),
+            Description: reader.IsDBNull(4) ? null : reader.GetString(4),
+            Extract: reader.IsDBNull(5) ? null : reader.GetString(5),
+            CommonName: reader.IsDBNull(6) ? null : reader.GetString(6),
+            Edible: reader.IsDBNull(7) ? null : reader.GetBoolean(7),
+            HardinessZones: reader.IsDBNull(8) ? null : reader.GetString(8),
+            ConservationStatus: reader.IsDBNull(9) ? null : reader.GetString(9),
+            TaxonRank: reader.IsDBNull(10) ? null : reader.GetString(10),
+            GbifTaxonId: reader.IsDBNull(11) ? null : reader.GetString(11),
+            ParentTaxonName: reader.IsDBNull(12) ? null : reader.GetString(12),
+            ParentTaxonWikidataId: reader.IsDBNull(13) ? null : reader.GetString(13)
+        );
+    }
+
+    private static WikipediaScraper BuildScraper(
+        NpgsqlConnection conn,
+        FakeHttpMessageHandler handler
+    ) => new WikipediaScraper(conn, new HttpClient(handler), Log.Logger);
+
+    // Standard fake responses for a fully-populated Rosa canina entry
+    private static FakeHttpMessageHandler FullHandler() =>
+        new FakeHttpMessageHandler()
+            .Add(
+                url => url.Contains("en.wikipedia.org/w/api.php") && url.Contains("list=search"),
+                """{"query":{"search":[{"title":"Rosa canina","pageid":123456}]}}"""
+            )
+            .Add(
+                url => url.Contains("en.wikipedia.org/api/rest_v1/page/summary/Rosa_canina"),
+                """
+                {
+                  "title": "Rosa canina",
+                  "pageid": 123456,
+                  "description": "species of rose",
+                  "extract": "Rosa canina grows in hardiness zones 4-9 across Europe.",
+                  "wikidata_item": "Q30014"
+                }
+                """
+            )
+            .Add(
+                url => url.Contains("da.wikipedia.org/api/rest_v1/page/summary/Hunderose"),
+                """
+                {
+                  "title": "Hunderose",
+                  "pageid": 654321,
+                  "description": "en roseart",
+                  "extract": "Hunderose er en plantearten.",
+                  "wikidata_item": "Q30014"
+                }
+                """
+            )
+            .Add(
+                url =>
+                    url.Contains("wikidata.org/w/api.php")
+                    && url.Contains("Q30014")
+                    && url.Contains("props=claims"),
+                """
+                {
+                  "entities": {
+                    "Q30014": {
+                      "claims": {
+                        "P171": [{"mainsnak":{"datavalue":{"type":"wikibase-entityid","value":{"id":"Q34740"}}}}],
+                        "P141": [{"mainsnak":{"datavalue":{"type":"wikibase-entityid","value":{"id":"Q211005"}}}}],
+                        "P105": [{"mainsnak":{"datavalue":{"type":"wikibase-entityid","value":{"id":"Q7432"}}}}],
+                        "P846": [{"mainsnak":{"datavalue":{"type":"string","value":"3021337"}}}],
+                        "P1843": [
+                          {"mainsnak":{"datavalue":{"type":"monolingualtext","value":{"text":"dog rose","language":"en"}}}},
+                          {"mainsnak":{"datavalue":{"type":"monolingualtext","value":{"text":"hunderose","language":"da"}}}}
+                        ],
+                        "P279": [{"mainsnak":{"datavalue":{"type":"wikibase-entityid","value":{"id":"Q145409"}}}}]
+                      },
+                      "sitelinks": {
+                        "enwiki": {"title":"Rosa canina"},
+                        "dawiki": {"title":"Hunderose"}
+                      }
+                    }
+                  }
+                }
+                """
+            )
+            .Add(
+                url =>
+                    url.Contains("wikidata.org/w/api.php")
+                    && url.Contains("Q34740")
+                    && url.Contains("props=labels"),
+                """{"entities":{"Q34740":{"labels":{"en":{"value":"Rosa"}}}}}"""
+            );
+
+    private record WikiRow(
+        string? WikipediaTitle,
+        string? WikipediaPageUrl,
+        int? WikipediaPageId,
+        string? WikidataId,
+        string? Description,
+        string? Extract,
+        string? CommonName,
+        bool? Edible,
+        string? HardinessZones,
+        string? ConservationStatus,
+        string? TaxonRank,
+        string? GbifTaxonId,
+        string? ParentTaxonName,
+        string? ParentTaxonWikidataId
+    );
+
+    // -------------------------------------------------------------------------
+    // Test fixtures
+    // -------------------------------------------------------------------------
+
+    [TestFixture]
+    public class WhenArticleFound : WikipediaScraperTests
+    {
+        [Test]
+        public async Task WritesEnglishRow()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await BuildScraper(_conn, FullHandler()).Scrape();
+
+            var row = await GetWikiRow(1, "en");
+            Assert.That(row, Is.Not.Null);
+            Assert.That(row!.WikipediaTitle, Is.EqualTo("Rosa canina"));
+            Assert.That(row.WikipediaPageId, Is.EqualTo(123456));
+            Assert.That(row.WikidataId, Is.EqualTo("Q30014"));
+            Assert.That(row.Description, Is.EqualTo("species of rose"));
+            Assert.That(row.Extract, Does.Contain("Rosa canina"));
+        }
+
+        [Test]
+        public async Task WikipediaPageUrlIsHumanReadable()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await BuildScraper(_conn, FullHandler()).Scrape();
+
+            var row = await GetWikiRow(1, "en");
+            Assert.That(
+                row!.WikipediaPageUrl,
+                Is.EqualTo("https://en.wikipedia.org/wiki/Rosa_canina")
+            );
+        }
+
+        [Test]
+        public async Task WritesDanishRowViaSitelink()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await BuildScraper(_conn, FullHandler()).Scrape();
+
+            var row = await GetWikiRow(1, "da");
+            Assert.That(row, Is.Not.Null);
+            Assert.That(row!.WikipediaTitle, Is.EqualTo("Hunderose"));
+            Assert.That(row.WikipediaPageId, Is.EqualTo(654321));
+            Assert.That(
+                row.WikipediaPageUrl,
+                Is.EqualTo("https://da.wikipedia.org/wiki/Hunderose")
+            );
+            Assert.That(row.Description, Is.EqualTo("en roseart"));
+        }
+
+        [Test]
+        public async Task PopulatesWikidataFields()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await BuildScraper(_conn, FullHandler()).Scrape();
+
+            var row = await GetWikiRow(1, "en");
+            Assert.That(row!.TaxonRank, Is.EqualTo("species"));
+            Assert.That(row.GbifTaxonId, Is.EqualTo("3021337"));
+            Assert.That(row.ConservationStatus, Is.EqualTo("Least Concern"));
+            Assert.That(row.ParentTaxonWikidataId, Is.EqualTo("Q34740"));
+            Assert.That(row.ParentTaxonName, Is.EqualTo("Rosa"));
+            Assert.That(row.Edible, Is.True);
+        }
+
+        [Test]
+        public async Task ParsesHardinessZonesFromExtract()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await BuildScraper(_conn, FullHandler()).Scrape();
+
+            var row = await GetWikiRow(1, "en");
+            Assert.That(row!.HardinessZones, Is.EqualTo("hardiness zones 4-9"));
+        }
+
+        [Test]
+        public async Task StoresLanguageSpecificCommonNames()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await BuildScraper(_conn, FullHandler()).Scrape();
+
+            var enRow = await GetWikiRow(1, "en");
+            var daRow = await GetWikiRow(1, "da");
+            Assert.That(enRow!.CommonName, Is.EqualTo("dog rose"));
+            Assert.That(daRow!.CommonName, Is.EqualTo("hunderose"));
+        }
+    }
+
+    [TestFixture]
+    public class WhenWikipediaSearchEmpty : WikipediaScraperTests
+    {
+        [Test]
+        public async Task InsertsEmptyRowsForAllLanguages()
+        {
+            await InsertSpecies(1, "Unknown Plant", "Fictus unknownus");
+            var handler = new FakeHttpMessageHandler().Add(
+                url => url.Contains("list=search"),
+                """{"query":{"search":[]}}"""
+            );
+
+            await BuildScraper(_conn, handler).Scrape();
+
+            var enRow = await GetWikiRow(1, "en");
+            var daRow = await GetWikiRow(1, "da");
+            Assert.That(enRow, Is.Not.Null);
+            Assert.That(enRow!.WikipediaTitle, Is.Null);
+            Assert.That(daRow, Is.Not.Null);
+            Assert.That(daRow!.WikipediaTitle, Is.Null);
+        }
+    }
+
+    [TestFixture]
+    public class WhenWikipediaReturnsError : WikipediaScraperTests
+    {
+        [Test]
+        public async Task InsertsEmptyRowsForAllLanguages()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            // Handler returns 404 for everything
+            await BuildScraper(_conn, new FakeHttpMessageHandler()).Scrape();
+
+            var enRow = await GetWikiRow(1, "en");
+            var daRow = await GetWikiRow(1, "da");
+            Assert.That(enRow, Is.Not.Null);
+            Assert.That(daRow, Is.Not.Null);
+        }
+    }
+
+    [TestFixture]
+    public class WhenNoDanishSitelink : WikipediaScraperTests
+    {
+        [Test]
+        public async Task DanishRowIsEmptyButEnglishIsPopulated()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            var handler = new FakeHttpMessageHandler()
+                .Add(
+                    url =>
+                        url.Contains("en.wikipedia.org/w/api.php") && url.Contains("list=search"),
+                    """{"query":{"search":[{"title":"Rosa canina","pageid":1}]}}"""
+                )
+                .Add(
+                    url => url.Contains("en.wikipedia.org/api/rest_v1/page/summary"),
+                    """{"title":"Rosa canina","pageid":1,"description":"a rose","wikidata_item":"Q1"}"""
+                )
+                .Add(
+                    url => url.Contains("Q1") && url.Contains("props=claims"),
+                    // No dawiki sitelink
+                    """{"entities":{"Q1":{"claims":{},"sitelinks":{"enwiki":{"title":"Rosa canina"}}}}}"""
+                );
+
+            await BuildScraper(_conn, handler).Scrape();
+
+            var enRow = await GetWikiRow(1, "en");
+            var daRow = await GetWikiRow(1, "da");
+            Assert.That(enRow!.WikipediaTitle, Is.EqualTo("Rosa canina"));
+            Assert.That(daRow, Is.Not.Null);
+            Assert.That(daRow!.WikipediaTitle, Is.Null); // empty placeholder row
+        }
+    }
+
+    [TestFixture]
+    public class Idempotency : WikipediaScraperTests
+    {
+        [Test]
+        public async Task AlreadyScrapedSpecies_IsSkippedOnRerun()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            var handler = FullHandler();
+
+            await BuildScraper(_conn, handler).Scrape();
+            var callCountAfterFirst = handler.CallCount;
+
+            // Second run — 'en' row already exists, scraper should skip
+            await BuildScraper(_conn, handler).Scrape();
+
+            Assert.That(handler.CallCount, Is.EqualTo(callCountAfterFirst));
+        }
+    }
+
+    [TestFixture]
+    public class MultipleSpecies : WikipediaScraperTests
+    {
+        [Test]
+        public async Task ScrapesEachSpeciesIndependently()
+        {
+            await InsertSpecies(1, "Dog Rose", "Rosa canina");
+            await InsertSpecies(2, "Stinging Nettle", "Urtica dioica");
+
+            var handler = new FakeHttpMessageHandler()
+                .Add(
+                    url => url.Contains("list=search") && url.Contains("Rosa+canina"),
+                    """{"query":{"search":[{"title":"Rosa canina","pageid":1}]}}"""
+                )
+                .Add(
+                    url => url.Contains("list=search") && url.Contains("Urtica+dioica"),
+                    """{"query":{"search":[{"title":"Urtica dioica","pageid":2}]}}"""
+                )
+                .Add(
+                    url => url.Contains("summary/Rosa_canina"),
+                    """{"title":"Rosa canina","pageid":1,"description":"a rose","wikidata_item":"Q1"}"""
+                )
+                .Add(
+                    url => url.Contains("summary/Urtica_dioica"),
+                    """{"title":"Urtica dioica","pageid":2,"description":"a nettle","wikidata_item":"Q2"}"""
+                )
+                .Add(
+                    url => url.Contains("wikidata.org") && url.Contains("claims"),
+                    """{"entities":{"Q1":{"claims":{},"sitelinks":{}},"Q2":{"claims":{},"sitelinks":{}}}}"""
+                );
+
+            await BuildScraper(_conn, handler).Scrape();
+
+            var rose = await GetWikiRow(1, "en");
+            var nettle = await GetWikiRow(2, "en");
+            Assert.That(rose!.Description, Is.EqualTo("a rose"));
+            Assert.That(nettle!.Description, Is.EqualTo("a nettle"));
+        }
+    }
+}

--- a/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
+++ b/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Text;
 using Npgsql;
 using NUnit.Framework;
 using Serilog;
@@ -99,7 +97,7 @@ public class WikipediaScraperTests
                   "pageid": 123456,
                   "description": "species of rose",
                   "extract": "Rosa canina grows in hardiness zones 4-9 across Europe.",
-                  "wikidata_item": "Q30014"
+                  "wikibase_item": "Q30014"
                 }
                 """
             )
@@ -111,7 +109,7 @@ public class WikipediaScraperTests
                   "pageid": 654321,
                   "description": "en roseart",
                   "extract": "Hunderose er en plantearten.",
-                  "wikidata_item": "Q30014"
+                  "wikibase_item": "Q30014"
                 }
                 """
             )
@@ -314,7 +312,7 @@ public class WikipediaScraperTests
                 )
                 .Add(
                     url => url.Contains("en.wikipedia.org/api/rest_v1/page/summary"),
-                    """{"title":"Rosa canina","pageid":1,"description":"a rose","wikidata_item":"Q1"}"""
+                    """{"title":"Rosa canina","pageid":1,"description":"a rose","wikibase_item":"Q1"}"""
                 )
                 .Add(
                     url => url.Contains("Q1") && url.Contains("props=claims"),
@@ -371,11 +369,11 @@ public class WikipediaScraperTests
                 )
                 .Add(
                     url => url.Contains("summary/Rosa_canina"),
-                    """{"title":"Rosa canina","pageid":1,"description":"a rose","wikidata_item":"Q1"}"""
+                    """{"title":"Rosa canina","pageid":1,"description":"a rose","wikibase_item":"Q1"}"""
                 )
                 .Add(
                     url => url.Contains("summary/Urtica_dioica"),
-                    """{"title":"Urtica dioica","pageid":2,"description":"a nettle","wikidata_item":"Q2"}"""
+                    """{"title":"Urtica dioica","pageid":2,"description":"a nettle","wikibase_item":"Q2"}"""
                 )
                 .Add(
                     url => url.Contains("wikidata.org") && url.Contains("claims"),
@@ -388,6 +386,37 @@ public class WikipediaScraperTests
             var nettle = await GetWikiRow(2, "en");
             Assert.That(rose!.Description, Is.EqualTo("a rose"));
             Assert.That(nettle!.Description, Is.EqualTo("a nettle"));
+        }
+    }
+
+    // Calls the real Wikipedia and Wikidata APIs — requires network access
+    [TestFixture]
+    public class AbiesConcolorLiveApi : WikipediaScraperTests
+    {
+        [Test]
+        public async Task ScrapesAbiesConcolor_PopulatesBothEnglishAndDanish()
+        {
+            await InsertSpecies(1, "White Fir", "Abies concolor");
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "Stikl/1.0 (integration test; https://github.com/c0dk/stikl)"
+            );
+            var scraper = new WikipediaScraper(_conn, httpClient, Log.Logger);
+            await scraper.Scrape();
+
+            var enRow = await GetWikiRow(1, "en");
+            var daRow = await GetWikiRow(1, "da");
+
+            Assert.That(enRow, Is.Not.Null);
+            Assert.That(enRow!.WikipediaTitle, Is.Not.Null.And.Not.Empty);
+            Assert.That(enRow.Description, Is.Not.Null.And.Not.Empty);
+            Assert.That(enRow.WikidataId, Is.Not.Null.And.Not.Empty);
+
+            // da.wikipedia.org/wiki/Hvidgran exists for Abies concolor
+            Assert.That(daRow, Is.Not.Null);
+            Assert.That(daRow!.WikipediaTitle, Is.Not.Null.And.Not.Empty);
+            Assert.That(daRow.Description, Is.Not.Null.And.Not.Empty);
         }
     }
 }

--- a/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
+++ b/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
@@ -357,16 +357,16 @@ public class WikipediaScraperTests
         [Test]
         public async Task ScrapesEachSpeciesIndependently()
         {
-            await InsertSpecies(1, "Dog Rose", "Rosa canina");
-            await InsertSpecies(2, "Stinging Nettle", "Urtica dioica");
+            await InsertSpecies(1, "Dog Rose", "Rosa");
+            await InsertSpecies(2, "Stinging Nettle", "Urtica");
 
             var handler = new FakeHttpMessageHandler()
                 .Add(
-                    url => url.Contains("list=search") && url.Contains("Rosa%20canina"),
+                    url => url.Contains("list=search") && url.Contains("Rosa"),
                     """{"query":{"search":[{"title":"Rosa canina","pageid":1}]}}"""
                 )
                 .Add(
-                    url => url.Contains("list=search") && url.Contains("Urtica%20dioica"),
+                    url => url.Contains("list=search") && url.Contains("Urtica"),
                     """{"query":{"search":[{"title":"Urtica dioica","pageid":2}]}}"""
                 )
                 .Add(

--- a/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
+++ b/app/Stikl.Tests/Integration/WikipediaScraperTests.cs
@@ -362,11 +362,11 @@ public class WikipediaScraperTests
 
             var handler = new FakeHttpMessageHandler()
                 .Add(
-                    url => url.Contains("list=search") && url.Contains("Rosa+canina"),
+                    url => url.Contains("list=search") && url.Contains("Rosa%20canina"),
                     """{"query":{"search":[{"title":"Rosa canina","pageid":1}]}}"""
                 )
                 .Add(
-                    url => url.Contains("list=search") && url.Contains("Urtica+dioica"),
+                    url => url.Contains("list=search") && url.Contains("Urtica%20dioica"),
                     """{"query":{"search":[{"title":"Urtica dioica","pageid":2}]}}"""
                 )
                 .Add(

--- a/app/Stikl.Web/Data/WikipediaScraper.cs
+++ b/app/Stikl.Web/Data/WikipediaScraper.cs
@@ -8,9 +8,16 @@ using NpgsqlTypes;
 namespace Stikl.Web.Data;
 
 /// <summary>
-/// Scrapes Wikipedia/Wikidata for each entry in perenual_species and stores the results
-/// in wiki_species_info. Fetches description, edibility, hardiness zones, conservation
-/// status, and parent taxon (for species-tree relationships).
+/// Scrapes Wikipedia and Wikidata for each entry in perenual_species and stores the
+/// results in wiki_species_info — one row per (species, language).
+///
+/// Per-language data: Wikipedia description, intro extract, common name (Wikidata P1843),
+/// page URL and title.
+///
+/// Language-agnostic Wikidata data (stored in every row): edibility (P279/P31 type
+/// hierarchy), USDA hardiness zones (regex on article text), IUCN conservation status
+/// (P141), taxon rank (P105), GBIF taxon ID (P846), and parent taxon (P171) for
+/// species-tree navigation.
 ///
 /// Run via: WIKI_SCRAPE=true dotnet run
 /// </summary>
@@ -21,7 +28,9 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         PropertyNameCaseInsensitive = true,
     };
 
-    // IUCN conservation status Wikidata IDs → human-readable labels
+    private static readonly string[] SupportedLanguages = ["en", "da"];
+
+    // IUCN conservation status Wikidata Q-IDs → human-readable labels
     private static readonly Dictionary<string, string> ConservationStatusLabels = new()
     {
         ["Q211005"] = "Least Concern",
@@ -35,7 +44,28 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         ["Q2708480"] = "Not Evaluated",
     };
 
-    // Wikidata Q-IDs that indicate a plant is edible
+    // Taxon rank Wikidata Q-IDs → labels (hardcoded to avoid extra API calls per species)
+    private static readonly Dictionary<string, string> TaxonRankLabels = new()
+    {
+        ["Q7432"] = "species",
+        ["Q34740"] = "genus",
+        ["Q35409"] = "family",
+        ["Q36602"] = "order",
+        ["Q37517"] = "class",
+        ["Q38348"] = "phylum",
+        ["Q36244"] = "kingdom",
+        ["Q68947"] = "variety",
+        ["Q767728"] = "subspecies",
+        ["Q4886"] = "cultivar",
+        ["Q310890"] = "section",
+        ["Q1065111"] = "series",
+        ["Q2455704"] = "tribe",
+        ["Q713623"] = "subgenus",
+        ["Q3025161"] = "subvariety",
+        ["Q2111609"] = "form",
+    };
+
+    // Wikidata Q-IDs whose presence in P279/P31 implies the plant is edible
     private static readonly HashSet<string> EdibleQIds =
     [
         "Q145409", // edible plant
@@ -46,7 +76,6 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         "Q207123", // edible fruit
         "Q728937", // culinary herb
         "Q80235", // fruit vegetable
-        "Q1055684", // edible mushroom (in case of fungi)
     ];
 
     public async ValueTask Scrape(CancellationToken cancellationToken = default)
@@ -62,13 +91,14 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
             if (cancellationToken.IsCancellationRequested)
                 break;
             await ScrapeOne(perenualId, scientificName, cancellationToken);
-            // Be a polite citizen: ~2 req/s to Wikipedia
+            // Be a polite citizen: ~2 req/s to Wikipedia/Wikidata
             await Task.Delay(500, cancellationToken);
         }
 
         logger.Information("Wikipedia scraping completed");
     }
 
+    // Returns species that are missing an 'en' row — we process all languages at once per species
     private async Task<List<(int Id, string ScientificName)>> GetUnscrapedSpecies(
         CancellationToken ct
     )
@@ -77,9 +107,11 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
             """
             SELECT p.perenual_id, p.scientific_name[1]
             FROM perenual_species p
-            LEFT JOIN wiki_species_info w ON p.perenual_id = w.perenual_id
-            WHERE w.perenual_id IS NULL
-              AND p.scientific_name[1] IS NOT NULL
+            WHERE p.scientific_name[1] IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM wiki_species_info w
+                  WHERE w.perenual_id = p.perenual_id AND w.lang = 'en'
+              )
             ORDER BY p.perenual_id
             """,
             connection
@@ -100,47 +132,76 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
             .Debug("Scraping Wikipedia");
         try
         {
-            var title = await SearchWikipedia(scientificName, ct);
-            if (title is null)
+            // 1. Search English Wikipedia by scientific name
+            var enTitle = await SearchWikipedia("en", scientificName, ct);
+            if (enTitle is null)
             {
-                await InsertEmpty(perenualId, ct);
+                foreach (var lang in SupportedLanguages)
+                    await InsertEmpty(perenualId, lang, ct);
                 return;
             }
 
-            var summary = await GetSummary(title, ct);
-            if (summary is null)
+            // 2. Fetch English summary → gives us the Wikidata item ID
+            var enSummary = await GetSummary("en", enTitle, ct);
+
+            // 3. Fetch Wikidata (claims + sitelinks) once for all languages
+            WikidataFull? wikidata = null;
+            if (enSummary?.WikidataItem is not null)
             {
-                await InsertEmpty(perenualId, ct);
-                return;
+                await Task.Delay(300, ct);
+                wikidata = await GetWikidataFull(enSummary.WikidataItem, ct);
             }
 
-            WikidataResult? wikidata = null;
-            if (summary.WikidataItem is not null)
-                wikidata = await GetWikidataResult(summary.WikidataItem, ct);
+            // 4. Write a row for each supported language
+            foreach (var lang in SupportedLanguages)
+            {
+                SummaryResponse? summary;
+                if (lang == "en")
+                {
+                    summary = enSummary;
+                }
+                else
+                {
+                    // Use Wikidata sitelinks to find the foreign-language Wikipedia title
+                    var foreignTitle = wikidata?.Sitelinks.GetValueOrDefault($"{lang}wiki")?.Title;
+                    if (foreignTitle is null)
+                    {
+                        await InsertEmpty(perenualId, lang, ct);
+                        continue;
+                    }
+                    await Task.Delay(300, ct);
+                    summary = await GetSummary(lang, foreignTitle, ct);
+                }
 
-            var hardinessZones = ExtractHardinessZones(summary.Extract);
-            await Insert(perenualId, summary, wikidata, hardinessZones, ct);
+                if (summary is null)
+                {
+                    await InsertEmpty(perenualId, lang, ct);
+                    continue;
+                }
 
-            logger
-                .ForContext("perenualId", perenualId)
-                .ForContext("wikidataId", summary.WikidataItem)
-                .Debug("Scraped Wikipedia successfully");
+                var commonName = wikidata?.CommonNames.GetValueOrDefault(lang);
+                var hardinessZones = ExtractHardinessZones(summary.Extract);
+                await Insert(perenualId, lang, summary, wikidata, commonName, hardinessZones, ct);
+            }
+
+            logger.ForContext("perenualId", perenualId).Debug("Wikipedia scrape complete");
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger
                 .ForContext("perenualId", perenualId)
-                .Warning(ex, "Wikipedia scrape failed, inserting empty record");
-            await InsertEmpty(perenualId, ct);
+                .Warning(ex, "Wikipedia scrape failed, inserting empty records");
+            foreach (var lang in SupportedLanguages)
+                await InsertEmpty(perenualId, lang, ct);
         }
     }
 
-    // Search Wikipedia by scientific name; returns page title of top result
-    private async Task<string?> SearchWikipedia(string query, CancellationToken ct)
+    // Search Wikipedia in the given language; returns page title of top result
+    private async Task<string?> SearchWikipedia(string lang, string query, CancellationToken ct)
     {
         var encoded = Uri.EscapeDataString(query);
         var url =
-            $"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch={encoded}&srlimit=1&srnamespace=0&format=json&utf8=";
+            $"https://{lang}.wikipedia.org/w/api.php?action=query&list=search&srsearch={encoded}&srlimit=1&srnamespace=0&format=json&utf8=";
         var resp = await http.GetAsync(url, ct);
         if (!resp.IsSuccessStatusCode)
             return null;
@@ -148,12 +209,12 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         return doc?.Query?.Search?.FirstOrDefault()?.Title;
     }
 
-    // Wikipedia REST summary API returns description, extract, and wikidata_item
-    private async Task<SummaryResponse?> GetSummary(string title, CancellationToken ct)
+    // Wikipedia REST summary: description, extract, wikidata_item, pageid
+    private async Task<SummaryResponse?> GetSummary(string lang, string title, CancellationToken ct)
     {
         var encoded = Uri.EscapeDataString(title.Replace(" ", "_"));
         var resp = await http.GetAsync(
-            $"https://en.wikipedia.org/api/rest_v1/page/summary/{encoded}",
+            $"https://{lang}.wikipedia.org/api/rest_v1/page/summary/{encoded}",
             ct
         );
         if (!resp.IsSuccessStatusCode)
@@ -161,10 +222,11 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         return await resp.Content.ReadFromJsonAsync<SummaryResponse>(JsonOptions, ct);
     }
 
-    private async Task<WikidataResult?> GetWikidataResult(string qid, CancellationToken ct)
+    private async Task<WikidataFull?> GetWikidataFull(string qid, CancellationToken ct)
     {
+        // Fetch claims + sitelinks in one request
         var url =
-            $"https://www.wikidata.org/w/api.php?action=wbgetentities&ids={qid}&props=claims&format=json";
+            $"https://www.wikidata.org/w/api.php?action=wbgetentities&ids={qid}&props=claims|sitelinks&format=json";
         var resp = await http.GetAsync(url, ct);
         if (!resp.IsSuccessStatusCode)
             return null;
@@ -173,46 +235,68 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         if (doc?.Entities is null || !doc.Entities.TryGetValue(qid, out var entity))
             return null;
 
-        var result = new WikidataResult();
+        var result = new WikidataFull { Sitelinks = entity.Sitelinks ?? [] };
 
         if (entity.Claims is null)
             return result;
 
-        // P171: parent taxon — gives one level up in the taxonomic tree
-        if (entity.Claims.TryGetValue("P171", out var parentClaims))
+        // P171: parent taxon (resolves label via a second Wikidata call)
+        var parentQid = GetFirstEntityId(entity.Claims, "P171");
+        if (parentQid is not null)
         {
-            var parentQid = parentClaims.FirstOrDefault()?.Mainsnak?.Datavalue?.Value?.Id;
-            if (parentQid is not null)
-            {
-                result.ParentTaxonWikidataId = parentQid;
-                await Task.Delay(200, ct);
-                result.ParentTaxonName = await GetEntityLabel(parentQid, ct);
-            }
+            result.ParentTaxonWikidataId = parentQid;
+            await Task.Delay(200, ct);
+            result.ParentTaxonName = await GetEntityLabel(parentQid, ct);
         }
 
         // P141: IUCN conservation status
-        if (entity.Claims.TryGetValue("P141", out var consClaims))
+        var consQid = GetFirstEntityId(entity.Claims, "P141");
+        if (consQid is not null && ConservationStatusLabels.TryGetValue(consQid, out var consLabel))
+            result.ConservationStatus = consLabel;
+
+        // P105: taxon rank (hardcoded label map — no extra API call needed)
+        var rankQid = GetFirstEntityId(entity.Claims, "P105");
+        if (rankQid is not null && TaxonRankLabels.TryGetValue(rankQid, out var rankLabel))
+            result.TaxonRank = rankLabel;
+
+        // P846: GBIF taxon ID (plain string value)
+        result.GbifTaxonId = GetFirstStringValue(entity.Claims, "P846");
+
+        // P1843: taxon common name (monolingualtext — one entry per language)
+        if (entity.Claims.TryGetValue("P1843", out var commonNameClaims))
         {
-            var consQid = consClaims.FirstOrDefault()?.Mainsnak?.Datavalue?.Value?.Id;
-            if (consQid is not null && ConservationStatusLabels.TryGetValue(consQid, out var label))
-                result.ConservationStatus = label;
+            foreach (var claim in commonNameClaims)
+            {
+                var dv = claim.Mainsnak?.Datavalue;
+                if (dv?.Type != "monolingualtext")
+                    continue;
+                var text = dv.Value.TryGetProperty("text", out var t) ? t.GetString() : null;
+                var nameLang = dv.Value.TryGetProperty("language", out var l)
+                    ? l.GetString()
+                    : null;
+                if (
+                    text is not null
+                    && nameLang is not null
+                    && !result.CommonNames.ContainsKey(nameLang)
+                )
+                    result.CommonNames[nameLang] = text;
+            }
         }
 
-        // P279 (subclass of) and P31 (instance of): check for edibility
+        // P279 (subclass of) / P31 (instance of): derive edibility
         var typeIds = entity
             .Claims.Where(c => c.Key is "P279" or "P31")
             .SelectMany(c => c.Value)
-            .Select(c => c.Mainsnak?.Datavalue?.Value?.Id)
+            .Select(c => GetEntityId(c.Mainsnak?.Datavalue))
             .OfType<string>()
             .ToHashSet();
-
         if (typeIds.Overlaps(EdibleQIds))
             result.Edible = true;
 
         return result;
     }
 
-    // Fetch the English label for a Wikidata entity (used to resolve parent taxon name)
+    // Fetch the English label for any Wikidata entity (used for parent taxon name)
     private async Task<string?> GetEntityLabel(string qid, CancellationToken ct)
     {
         var url =
@@ -224,6 +308,38 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         if (doc?.Entities is null || !doc.Entities.TryGetValue(qid, out var entity))
             return null;
         return entity.Labels?.TryGetValue("en", out var label) == true ? label.Value : null;
+    }
+
+    // Helpers for extracting typed values from polymorphic WdDatavalue.Value (JsonElement)
+
+    private static string? GetFirstEntityId(
+        Dictionary<string, WdClaim[]> claims,
+        string property
+    ) =>
+        claims.TryGetValue(property, out var cs)
+            ? GetEntityId(cs.FirstOrDefault()?.Mainsnak?.Datavalue)
+            : null;
+
+    private static string? GetFirstStringValue(
+        Dictionary<string, WdClaim[]> claims,
+        string property
+    ) =>
+        claims.TryGetValue(property, out var cs)
+            ? GetStringValue(cs.FirstOrDefault()?.Mainsnak?.Datavalue)
+            : null;
+
+    private static string? GetEntityId(WdDatavalue? dv)
+    {
+        if (dv?.Type != "wikibase-entityid")
+            return null;
+        return dv.Value.TryGetProperty("id", out var p) ? p.GetString() : null;
+    }
+
+    private static string? GetStringValue(WdDatavalue? dv)
+    {
+        if (dv?.Type != "string")
+            return null;
+        return dv.Value.ValueKind == JsonValueKind.String ? dv.Value.GetString() : null;
     }
 
     // Extracts USDA hardiness zone ranges from Wikipedia article text
@@ -243,31 +359,48 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
 
     private async ValueTask Insert(
         int perenualId,
+        string lang,
         SummaryResponse summary,
-        WikidataResult? wikidata,
+        WikidataFull? wikidata,
+        string? commonName,
         string? hardinessZones,
         CancellationToken ct
     )
     {
+        // Construct human-readable Wikipedia URL from title
+        var pageUrl = summary.Title is not null
+            ? $"https://{lang}.wikipedia.org/wiki/{Uri.EscapeDataString(summary.Title.Replace(" ", "_"))}"
+            : null;
+
         await using var cmd = new NpgsqlCommand(
             """
             INSERT INTO wiki_species_info (
-                perenual_id, wikipedia_title, wikipedia_page_id, wikidata_id,
-                description, extract, edible, hardiness_zones,
-                conservation_status, parent_taxon_name, parent_taxon_wikidata_id
+                perenual_id, lang,
+                wikipedia_title, wikipedia_page_url, wikipedia_page_id, wikidata_id,
+                description, extract, common_name,
+                edible, hardiness_zones, conservation_status,
+                taxon_rank, gbif_taxon_id,
+                parent_taxon_name, parent_taxon_wikidata_id
             ) VALUES (
-                @perenualId, @title, @pageId, @wikidataId,
-                @description, @extract, @edible, @hardinessZones,
-                @conservationStatus, @parentTaxonName, @parentTaxonWikidataId
-            ) ON CONFLICT (perenual_id) DO UPDATE SET
+                @perenualId, @lang,
+                @title, @pageUrl, @pageId, @wikidataId,
+                @description, @extract, @commonName,
+                @edible, @hardinessZones, @conservationStatus,
+                @taxonRank, @gbifTaxonId,
+                @parentTaxonName, @parentTaxonWikidataId
+            ) ON CONFLICT (perenual_id, lang) DO UPDATE SET
                 wikipedia_title          = EXCLUDED.wikipedia_title,
+                wikipedia_page_url       = EXCLUDED.wikipedia_page_url,
                 wikipedia_page_id        = EXCLUDED.wikipedia_page_id,
                 wikidata_id              = EXCLUDED.wikidata_id,
                 description              = EXCLUDED.description,
                 extract                  = EXCLUDED.extract,
+                common_name              = EXCLUDED.common_name,
                 edible                   = EXCLUDED.edible,
                 hardiness_zones          = EXCLUDED.hardiness_zones,
                 conservation_status      = EXCLUDED.conservation_status,
+                taxon_rank               = EXCLUDED.taxon_rank,
+                gbif_taxon_id            = EXCLUDED.gbif_taxon_id,
                 parent_taxon_name        = EXCLUDED.parent_taxon_name,
                 parent_taxon_wikidata_id = EXCLUDED.parent_taxon_wikidata_id,
                 scraped_at               = now()
@@ -276,44 +409,44 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         );
 
         cmd.Parameters.AddWithValue("perenualId", perenualId);
+        AddText(cmd, "lang", lang);
         AddText(cmd, "title", summary.Title);
+        AddText(cmd, "pageUrl", pageUrl);
         AddInt(cmd, "pageId", summary.PageId);
         AddText(cmd, "wikidataId", summary.WikidataItem);
         AddText(cmd, "description", summary.Description);
         AddText(cmd, "extract", summary.Extract);
+        AddText(cmd, "commonName", commonName);
         AddBool(cmd, "edible", wikidata?.Edible);
         AddText(cmd, "hardinessZones", hardinessZones);
         AddText(cmd, "conservationStatus", wikidata?.ConservationStatus);
+        AddText(cmd, "taxonRank", wikidata?.TaxonRank);
+        AddText(cmd, "gbifTaxonId", wikidata?.GbifTaxonId);
         AddText(cmd, "parentTaxonName", wikidata?.ParentTaxonName);
         AddText(cmd, "parentTaxonWikidataId", wikidata?.ParentTaxonWikidataId);
 
         await cmd.ExecuteNonQueryAsync(ct);
     }
 
-    private async ValueTask InsertEmpty(int perenualId, CancellationToken ct)
+    private async ValueTask InsertEmpty(int perenualId, string lang, CancellationToken ct)
     {
         await using var cmd = new NpgsqlCommand(
-            "INSERT INTO wiki_species_info (perenual_id) VALUES (@id) ON CONFLICT DO NOTHING",
+            "INSERT INTO wiki_species_info (perenual_id, lang) VALUES (@id, @lang) ON CONFLICT DO NOTHING",
             connection
         );
         cmd.Parameters.AddWithValue("id", perenualId);
+        cmd.Parameters.AddWithValue("lang", lang);
         await cmd.ExecuteNonQueryAsync(ct);
     }
 
-    private static void AddText(NpgsqlCommand cmd, string name, string? value)
-    {
+    private static void AddText(NpgsqlCommand cmd, string name, string? value) =>
         cmd.Parameters.Add(name, NpgsqlDbType.Text).Value = (object?)value ?? DBNull.Value;
-    }
 
-    private static void AddInt(NpgsqlCommand cmd, string name, int? value)
-    {
+    private static void AddInt(NpgsqlCommand cmd, string name, int? value) =>
         cmd.Parameters.Add(name, NpgsqlDbType.Integer).Value = (object?)value ?? DBNull.Value;
-    }
 
-    private static void AddBool(NpgsqlCommand cmd, string name, bool? value)
-    {
+    private static void AddBool(NpgsqlCommand cmd, string name, bool? value) =>
         cmd.Parameters.Add(name, NpgsqlDbType.Boolean).Value = (object?)value ?? DBNull.Value;
-    }
 
     // --- DTOs ---
 
@@ -340,25 +473,38 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
 
     private record WdEntity(
         [property: JsonPropertyName("claims")] Dictionary<string, WdClaim[]>? Claims,
-        [property: JsonPropertyName("labels")] Dictionary<string, WdLabel>? Labels
+        [property: JsonPropertyName("labels")] Dictionary<string, WdLabel>? Labels,
+        [property: JsonPropertyName("sitelinks")] Dictionary<string, WdSitelink>? Sitelinks
     );
+
+    private record WdSitelink([property: JsonPropertyName("title")] string? Title);
 
     private record WdClaim([property: JsonPropertyName("mainsnak")] WdMainsnak? Mainsnak);
 
     private record WdMainsnak([property: JsonPropertyName("datavalue")] WdDatavalue? Datavalue);
 
-    private record WdDatavalue([property: JsonPropertyName("value")] WdValue? Value);
-
-    // Wikidata entity-type values use an "id" field (e.g. "Q12345")
-    private record WdValue([property: JsonPropertyName("id")] string? Id);
+    // Value is polymorphic (entity-id object, monolingualtext object, or plain string)
+    // so we keep it as JsonElement and extract via type-checked helpers
+    private record WdDatavalue(
+        [property: JsonPropertyName("type")] string? Type,
+        [property: JsonPropertyName("value")] JsonElement Value
+    );
 
     private record WdLabel([property: JsonPropertyName("value")] string? Value);
 
-    private sealed class WikidataResult
+    private sealed class WikidataFull
     {
         public string? ParentTaxonWikidataId { get; set; }
         public string? ParentTaxonName { get; set; }
         public string? ConservationStatus { get; set; }
+        public string? TaxonRank { get; set; }
+        public string? GbifTaxonId { get; set; }
         public bool? Edible { get; set; }
+
+        // P1843 common names keyed by ISO 639-1 language code
+        public Dictionary<string, string> CommonNames { get; set; } = [];
+
+        // Wikidata sitelinks keyed by site name (e.g. "enwiki", "dawiki")
+        public Dictionary<string, WdSitelink> Sitelinks { get; set; } = [];
     }
 }

--- a/app/Stikl.Web/Data/WikipediaScraper.cs
+++ b/app/Stikl.Web/Data/WikipediaScraper.cs
@@ -464,7 +464,7 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         [property: JsonPropertyName("pageid")] int? PageId,
         [property: JsonPropertyName("description")] string? Description,
         [property: JsonPropertyName("extract")] string? Extract,
-        [property: JsonPropertyName("wikidata_item")] string? WikidataItem
+        [property: JsonPropertyName("wikibase_item")] string? WikidataItem
     );
 
     private record WdEntitiesResponse(

--- a/app/Stikl.Web/Data/WikipediaScraper.cs
+++ b/app/Stikl.Web/Data/WikipediaScraper.cs
@@ -1,0 +1,364 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Stikl.Web.Data;
+
+/// <summary>
+/// Scrapes Wikipedia/Wikidata for each entry in perenual_species and stores the results
+/// in wiki_species_info. Fetches description, edibility, hardiness zones, conservation
+/// status, and parent taxon (for species-tree relationships).
+///
+/// Run via: WIKI_SCRAPE=true dotnet run
+/// </summary>
+public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient http, ILogger logger)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // IUCN conservation status Wikidata IDs → human-readable labels
+    private static readonly Dictionary<string, string> ConservationStatusLabels = new()
+    {
+        ["Q211005"] = "Least Concern",
+        ["Q719675"] = "Near Threatened",
+        ["Q278113"] = "Vulnerable",
+        ["Q11394"] = "Endangered",
+        ["Q219127"] = "Critically Endangered",
+        ["Q239509"] = "Extinct in the Wild",
+        ["Q237350"] = "Extinct",
+        ["Q3245245"] = "Data Deficient",
+        ["Q2708480"] = "Not Evaluated",
+    };
+
+    // Wikidata Q-IDs that indicate a plant is edible
+    private static readonly HashSet<string> EdibleQIds =
+    [
+        "Q145409", // edible plant
+        "Q11004", // vegetable
+        "Q3314483", // fruit
+        "Q1364", // herb
+        "Q2820052", // food plant
+        "Q207123", // edible fruit
+        "Q728937", // culinary herb
+        "Q80235", // fruit vegetable
+        "Q1055684", // edible mushroom (in case of fungi)
+    ];
+
+    public async ValueTask Scrape(CancellationToken cancellationToken = default)
+    {
+        logger.Information("Starting Wikipedia plant scraper");
+        var species = await GetUnscrapedSpecies(cancellationToken);
+        logger
+            .ForContext("count", species.Count)
+            .Information("Found species to scrape from Wikipedia");
+
+        foreach (var (perenualId, scientificName) in species)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+            await ScrapeOne(perenualId, scientificName, cancellationToken);
+            // Be a polite citizen: ~2 req/s to Wikipedia
+            await Task.Delay(500, cancellationToken);
+        }
+
+        logger.Information("Wikipedia scraping completed");
+    }
+
+    private async Task<List<(int Id, string ScientificName)>> GetUnscrapedSpecies(
+        CancellationToken ct
+    )
+    {
+        await using var cmd = new NpgsqlCommand(
+            """
+            SELECT p.perenual_id, p.scientific_name[1]
+            FROM perenual_species p
+            LEFT JOIN wiki_species_info w ON p.perenual_id = w.perenual_id
+            WHERE w.perenual_id IS NULL
+              AND p.scientific_name[1] IS NOT NULL
+            ORDER BY p.perenual_id
+            """,
+            connection
+        );
+
+        var results = new List<(int, string)>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            results.Add((reader.GetInt32(0), reader.GetString(1)));
+        return results;
+    }
+
+    private async ValueTask ScrapeOne(int perenualId, string scientificName, CancellationToken ct)
+    {
+        logger
+            .ForContext("perenualId", perenualId)
+            .ForContext("scientificName", scientificName)
+            .Debug("Scraping Wikipedia");
+        try
+        {
+            var title = await SearchWikipedia(scientificName, ct);
+            if (title is null)
+            {
+                await InsertEmpty(perenualId, ct);
+                return;
+            }
+
+            var summary = await GetSummary(title, ct);
+            if (summary is null)
+            {
+                await InsertEmpty(perenualId, ct);
+                return;
+            }
+
+            WikidataResult? wikidata = null;
+            if (summary.WikidataItem is not null)
+                wikidata = await GetWikidataResult(summary.WikidataItem, ct);
+
+            var hardinessZones = ExtractHardinessZones(summary.Extract);
+            await Insert(perenualId, summary, wikidata, hardinessZones, ct);
+
+            logger
+                .ForContext("perenualId", perenualId)
+                .ForContext("wikidataId", summary.WikidataItem)
+                .Debug("Scraped Wikipedia successfully");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger
+                .ForContext("perenualId", perenualId)
+                .Warning(ex, "Wikipedia scrape failed, inserting empty record");
+            await InsertEmpty(perenualId, ct);
+        }
+    }
+
+    // Search Wikipedia by scientific name; returns page title of top result
+    private async Task<string?> SearchWikipedia(string query, CancellationToken ct)
+    {
+        var encoded = Uri.EscapeDataString(query);
+        var url =
+            $"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch={encoded}&srlimit=1&srnamespace=0&format=json&utf8=";
+        var resp = await http.GetAsync(url, ct);
+        if (!resp.IsSuccessStatusCode)
+            return null;
+        var doc = await resp.Content.ReadFromJsonAsync<WikiSearchResponse>(JsonOptions, ct);
+        return doc?.Query?.Search?.FirstOrDefault()?.Title;
+    }
+
+    // Wikipedia REST summary API returns description, extract, and wikidata_item
+    private async Task<SummaryResponse?> GetSummary(string title, CancellationToken ct)
+    {
+        var encoded = Uri.EscapeDataString(title.Replace(" ", "_"));
+        var resp = await http.GetAsync(
+            $"https://en.wikipedia.org/api/rest_v1/page/summary/{encoded}",
+            ct
+        );
+        if (!resp.IsSuccessStatusCode)
+            return null;
+        return await resp.Content.ReadFromJsonAsync<SummaryResponse>(JsonOptions, ct);
+    }
+
+    private async Task<WikidataResult?> GetWikidataResult(string qid, CancellationToken ct)
+    {
+        var url =
+            $"https://www.wikidata.org/w/api.php?action=wbgetentities&ids={qid}&props=claims&format=json";
+        var resp = await http.GetAsync(url, ct);
+        if (!resp.IsSuccessStatusCode)
+            return null;
+
+        var doc = await resp.Content.ReadFromJsonAsync<WdEntitiesResponse>(JsonOptions, ct);
+        if (doc?.Entities is null || !doc.Entities.TryGetValue(qid, out var entity))
+            return null;
+
+        var result = new WikidataResult();
+
+        if (entity.Claims is null)
+            return result;
+
+        // P171: parent taxon — gives one level up in the taxonomic tree
+        if (entity.Claims.TryGetValue("P171", out var parentClaims))
+        {
+            var parentQid = parentClaims.FirstOrDefault()?.Mainsnak?.Datavalue?.Value?.Id;
+            if (parentQid is not null)
+            {
+                result.ParentTaxonWikidataId = parentQid;
+                await Task.Delay(200, ct);
+                result.ParentTaxonName = await GetEntityLabel(parentQid, ct);
+            }
+        }
+
+        // P141: IUCN conservation status
+        if (entity.Claims.TryGetValue("P141", out var consClaims))
+        {
+            var consQid = consClaims.FirstOrDefault()?.Mainsnak?.Datavalue?.Value?.Id;
+            if (consQid is not null && ConservationStatusLabels.TryGetValue(consQid, out var label))
+                result.ConservationStatus = label;
+        }
+
+        // P279 (subclass of) and P31 (instance of): check for edibility
+        var typeIds = entity
+            .Claims.Where(c => c.Key is "P279" or "P31")
+            .SelectMany(c => c.Value)
+            .Select(c => c.Mainsnak?.Datavalue?.Value?.Id)
+            .OfType<string>()
+            .ToHashSet();
+
+        if (typeIds.Overlaps(EdibleQIds))
+            result.Edible = true;
+
+        return result;
+    }
+
+    // Fetch the English label for a Wikidata entity (used to resolve parent taxon name)
+    private async Task<string?> GetEntityLabel(string qid, CancellationToken ct)
+    {
+        var url =
+            $"https://www.wikidata.org/w/api.php?action=wbgetentities&ids={qid}&props=labels&format=json&languages=en";
+        var resp = await http.GetAsync(url, ct);
+        if (!resp.IsSuccessStatusCode)
+            return null;
+        var doc = await resp.Content.ReadFromJsonAsync<WdEntitiesResponse>(JsonOptions, ct);
+        if (doc?.Entities is null || !doc.Entities.TryGetValue(qid, out var entity))
+            return null;
+        return entity.Labels?.TryGetValue("en", out var label) == true ? label.Value : null;
+    }
+
+    // Extracts USDA hardiness zone ranges from Wikipedia article text
+    [GeneratedRegex(
+        @"(?:USDA\s+)?(?:hardiness\s+)?zones?\s+(\d+(?:[ab])?(?:\s*[-–]\s*\d+(?:[ab])?)?)",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex HardinessZoneRegex();
+
+    private static string? ExtractHardinessZones(string? extract)
+    {
+        if (string.IsNullOrWhiteSpace(extract))
+            return null;
+        var match = HardinessZoneRegex().Match(extract);
+        return match.Success ? match.Value : null;
+    }
+
+    private async ValueTask Insert(
+        int perenualId,
+        SummaryResponse summary,
+        WikidataResult? wikidata,
+        string? hardinessZones,
+        CancellationToken ct
+    )
+    {
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO wiki_species_info (
+                perenual_id, wikipedia_title, wikipedia_page_id, wikidata_id,
+                description, extract, edible, hardiness_zones,
+                conservation_status, parent_taxon_name, parent_taxon_wikidata_id
+            ) VALUES (
+                @perenualId, @title, @pageId, @wikidataId,
+                @description, @extract, @edible, @hardinessZones,
+                @conservationStatus, @parentTaxonName, @parentTaxonWikidataId
+            ) ON CONFLICT (perenual_id) DO UPDATE SET
+                wikipedia_title          = EXCLUDED.wikipedia_title,
+                wikipedia_page_id        = EXCLUDED.wikipedia_page_id,
+                wikidata_id              = EXCLUDED.wikidata_id,
+                description              = EXCLUDED.description,
+                extract                  = EXCLUDED.extract,
+                edible                   = EXCLUDED.edible,
+                hardiness_zones          = EXCLUDED.hardiness_zones,
+                conservation_status      = EXCLUDED.conservation_status,
+                parent_taxon_name        = EXCLUDED.parent_taxon_name,
+                parent_taxon_wikidata_id = EXCLUDED.parent_taxon_wikidata_id,
+                scraped_at               = now()
+            """,
+            connection
+        );
+
+        cmd.Parameters.AddWithValue("perenualId", perenualId);
+        AddText(cmd, "title", summary.Title);
+        AddInt(cmd, "pageId", summary.PageId);
+        AddText(cmd, "wikidataId", summary.WikidataItem);
+        AddText(cmd, "description", summary.Description);
+        AddText(cmd, "extract", summary.Extract);
+        AddBool(cmd, "edible", wikidata?.Edible);
+        AddText(cmd, "hardinessZones", hardinessZones);
+        AddText(cmd, "conservationStatus", wikidata?.ConservationStatus);
+        AddText(cmd, "parentTaxonName", wikidata?.ParentTaxonName);
+        AddText(cmd, "parentTaxonWikidataId", wikidata?.ParentTaxonWikidataId);
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private async ValueTask InsertEmpty(int perenualId, CancellationToken ct)
+    {
+        await using var cmd = new NpgsqlCommand(
+            "INSERT INTO wiki_species_info (perenual_id) VALUES (@id) ON CONFLICT DO NOTHING",
+            connection
+        );
+        cmd.Parameters.AddWithValue("id", perenualId);
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private static void AddText(NpgsqlCommand cmd, string name, string? value)
+    {
+        cmd.Parameters.Add(name, NpgsqlDbType.Text).Value = (object?)value ?? DBNull.Value;
+    }
+
+    private static void AddInt(NpgsqlCommand cmd, string name, int? value)
+    {
+        cmd.Parameters.Add(name, NpgsqlDbType.Integer).Value = (object?)value ?? DBNull.Value;
+    }
+
+    private static void AddBool(NpgsqlCommand cmd, string name, bool? value)
+    {
+        cmd.Parameters.Add(name, NpgsqlDbType.Boolean).Value = (object?)value ?? DBNull.Value;
+    }
+
+    // --- DTOs ---
+
+    private record WikiSearchResponse([property: JsonPropertyName("query")] WikiQuery? Query);
+
+    private record WikiQuery([property: JsonPropertyName("search")] WikiSearchItem[]? Search);
+
+    private record WikiSearchItem(
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("pageid")] int PageId
+    );
+
+    private record SummaryResponse(
+        [property: JsonPropertyName("title")] string? Title,
+        [property: JsonPropertyName("pageid")] int? PageId,
+        [property: JsonPropertyName("description")] string? Description,
+        [property: JsonPropertyName("extract")] string? Extract,
+        [property: JsonPropertyName("wikidata_item")] string? WikidataItem
+    );
+
+    private record WdEntitiesResponse(
+        [property: JsonPropertyName("entities")] Dictionary<string, WdEntity>? Entities
+    );
+
+    private record WdEntity(
+        [property: JsonPropertyName("claims")] Dictionary<string, WdClaim[]>? Claims,
+        [property: JsonPropertyName("labels")] Dictionary<string, WdLabel>? Labels
+    );
+
+    private record WdClaim([property: JsonPropertyName("mainsnak")] WdMainsnak? Mainsnak);
+
+    private record WdMainsnak([property: JsonPropertyName("datavalue")] WdDatavalue? Datavalue);
+
+    private record WdDatavalue([property: JsonPropertyName("value")] WdValue? Value);
+
+    // Wikidata entity-type values use an "id" field (e.g. "Q12345")
+    private record WdValue([property: JsonPropertyName("id")] string? Id);
+
+    private record WdLabel([property: JsonPropertyName("value")] string? Value);
+
+    private sealed class WikidataResult
+    {
+        public string? ParentTaxonWikidataId { get; set; }
+        public string? ParentTaxonName { get; set; }
+        public string? ConservationStatus { get; set; }
+        public bool? Edible { get; set; }
+    }
+}

--- a/app/Stikl.Web/Data/WikipediaScraper.cs
+++ b/app/Stikl.Web/Data/WikipediaScraper.cs
@@ -124,6 +124,86 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         return results;
     }
 
+    // Fetches Wikipedia/Wikidata data for one scientific name and returns one row per
+    // supported language. Rows with a null WikipediaTitle mean no article was found.
+    // Does not touch the database.
+    public async Task<IReadOnlyList<WikiSpeciesRow>> FetchSpeciesRows(
+        string scientificName,
+        CancellationToken ct = default
+    )
+    {
+        // 1. Search English Wikipedia by scientific name
+        var enTitle = await SearchWikipedia("en", scientificName, ct);
+        if (enTitle is null)
+            return SupportedLanguages.Select(lang => new WikiSpeciesRow(lang)).ToList();
+
+        // 2. Fetch English summary → gives us the Wikidata item ID
+        var enSummary = await GetSummary("en", enTitle, ct);
+
+        // 3. Fetch Wikidata (claims + sitelinks) once for all languages
+        WikidataFull? wikidata = null;
+        if (enSummary?.WikidataItem is not null)
+        {
+            await Task.Delay(300, ct);
+            wikidata = await GetWikidataFull(enSummary.WikidataItem, ct);
+        }
+
+        // 4. Build a row for each supported language
+        var rows = new List<WikiSpeciesRow>();
+        foreach (var lang in SupportedLanguages)
+        {
+            SummaryResponse? summary;
+            if (lang == "en")
+            {
+                summary = enSummary;
+            }
+            else
+            {
+                // Use Wikidata sitelinks to find the foreign-language Wikipedia title
+                var foreignTitle = wikidata?.Sitelinks.GetValueOrDefault($"{lang}wiki")?.Title;
+                if (foreignTitle is null)
+                {
+                    rows.Add(new WikiSpeciesRow(lang));
+                    continue;
+                }
+                await Task.Delay(300, ct);
+                summary = await GetSummary(lang, foreignTitle, ct);
+            }
+
+            if (summary is null)
+            {
+                rows.Add(new WikiSpeciesRow(lang));
+                continue;
+            }
+
+            var pageUrl = summary.Title is not null
+                ? $"https://{lang}.wikipedia.org/wiki/{Uri.EscapeDataString(summary.Title.Replace(" ", "_"))}"
+                : null;
+
+            rows.Add(
+                new WikiSpeciesRow(lang)
+                {
+                    WikipediaTitle = summary.Title,
+                    WikipediaPageUrl = pageUrl,
+                    WikipediaPageId = summary.PageId,
+                    WikidataId = summary.WikidataItem,
+                    Description = summary.Description,
+                    Extract = summary.Extract,
+                    CommonName = wikidata?.CommonNames.GetValueOrDefault(lang),
+                    Edible = wikidata?.Edible,
+                    HardinessZones = ExtractHardinessZones(summary.Extract),
+                    ConservationStatus = wikidata?.ConservationStatus,
+                    TaxonRank = wikidata?.TaxonRank,
+                    GbifTaxonId = wikidata?.GbifTaxonId,
+                    ParentTaxonName = wikidata?.ParentTaxonName,
+                    ParentTaxonWikidataId = wikidata?.ParentTaxonWikidataId,
+                }
+            );
+        }
+
+        return rows;
+    }
+
     private async ValueTask ScrapeOne(int perenualId, string scientificName, CancellationToken ct)
     {
         logger
@@ -132,58 +212,14 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
             .Debug("Scraping Wikipedia");
         try
         {
-            // 1. Search English Wikipedia by scientific name
-            var enTitle = await SearchWikipedia("en", scientificName, ct);
-            if (enTitle is null)
+            var rows = await FetchSpeciesRows(scientificName, ct);
+            foreach (var row in rows)
             {
-                foreach (var lang in SupportedLanguages)
-                    await InsertEmpty(perenualId, lang, ct);
-                return;
-            }
-
-            // 2. Fetch English summary → gives us the Wikidata item ID
-            var enSummary = await GetSummary("en", enTitle, ct);
-
-            // 3. Fetch Wikidata (claims + sitelinks) once for all languages
-            WikidataFull? wikidata = null;
-            if (enSummary?.WikidataItem is not null)
-            {
-                await Task.Delay(300, ct);
-                wikidata = await GetWikidataFull(enSummary.WikidataItem, ct);
-            }
-
-            // 4. Write a row for each supported language
-            foreach (var lang in SupportedLanguages)
-            {
-                SummaryResponse? summary;
-                if (lang == "en")
-                {
-                    summary = enSummary;
-                }
+                if (row.WikipediaTitle is null)
+                    await InsertEmpty(perenualId, row.Lang, ct);
                 else
-                {
-                    // Use Wikidata sitelinks to find the foreign-language Wikipedia title
-                    var foreignTitle = wikidata?.Sitelinks.GetValueOrDefault($"{lang}wiki")?.Title;
-                    if (foreignTitle is null)
-                    {
-                        await InsertEmpty(perenualId, lang, ct);
-                        continue;
-                    }
-                    await Task.Delay(300, ct);
-                    summary = await GetSummary(lang, foreignTitle, ct);
-                }
-
-                if (summary is null)
-                {
-                    await InsertEmpty(perenualId, lang, ct);
-                    continue;
-                }
-
-                var commonName = wikidata?.CommonNames.GetValueOrDefault(lang);
-                var hardinessZones = ExtractHardinessZones(summary.Extract);
-                await Insert(perenualId, lang, summary, wikidata, commonName, hardinessZones, ct);
+                    await Insert(perenualId, row, ct);
             }
-
             logger.ForContext("perenualId", perenualId).Debug("Wikipedia scrape complete");
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -357,21 +393,8 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         return match.Success ? match.Value : null;
     }
 
-    private async ValueTask Insert(
-        int perenualId,
-        string lang,
-        SummaryResponse summary,
-        WikidataFull? wikidata,
-        string? commonName,
-        string? hardinessZones,
-        CancellationToken ct
-    )
+    private async ValueTask Insert(int perenualId, WikiSpeciesRow row, CancellationToken ct)
     {
-        // Construct human-readable Wikipedia URL from title
-        var pageUrl = summary.Title is not null
-            ? $"https://{lang}.wikipedia.org/wiki/{Uri.EscapeDataString(summary.Title.Replace(" ", "_"))}"
-            : null;
-
         await using var cmd = new NpgsqlCommand(
             """
             INSERT INTO wiki_species_info (
@@ -409,21 +432,21 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         );
 
         cmd.Parameters.AddWithValue("perenualId", perenualId);
-        AddText(cmd, "lang", lang);
-        AddText(cmd, "title", summary.Title);
-        AddText(cmd, "pageUrl", pageUrl);
-        AddInt(cmd, "pageId", summary.PageId);
-        AddText(cmd, "wikidataId", summary.WikidataItem);
-        AddText(cmd, "description", summary.Description);
-        AddText(cmd, "extract", summary.Extract);
-        AddText(cmd, "commonName", commonName);
-        AddBool(cmd, "edible", wikidata?.Edible);
-        AddText(cmd, "hardinessZones", hardinessZones);
-        AddText(cmd, "conservationStatus", wikidata?.ConservationStatus);
-        AddText(cmd, "taxonRank", wikidata?.TaxonRank);
-        AddText(cmd, "gbifTaxonId", wikidata?.GbifTaxonId);
-        AddText(cmd, "parentTaxonName", wikidata?.ParentTaxonName);
-        AddText(cmd, "parentTaxonWikidataId", wikidata?.ParentTaxonWikidataId);
+        AddText(cmd, "lang", row.Lang);
+        AddText(cmd, "title", row.WikipediaTitle);
+        AddText(cmd, "pageUrl", row.WikipediaPageUrl);
+        AddInt(cmd, "pageId", row.WikipediaPageId);
+        AddText(cmd, "wikidataId", row.WikidataId);
+        AddText(cmd, "description", row.Description);
+        AddText(cmd, "extract", row.Extract);
+        AddText(cmd, "commonName", row.CommonName);
+        AddBool(cmd, "edible", row.Edible);
+        AddText(cmd, "hardinessZones", row.HardinessZones);
+        AddText(cmd, "conservationStatus", row.ConservationStatus);
+        AddText(cmd, "taxonRank", row.TaxonRank);
+        AddText(cmd, "gbifTaxonId", row.GbifTaxonId);
+        AddText(cmd, "parentTaxonName", row.ParentTaxonName);
+        AddText(cmd, "parentTaxonWikidataId", row.ParentTaxonWikidataId);
 
         await cmd.ExecuteNonQueryAsync(ct);
     }
@@ -507,4 +530,27 @@ public partial class WikipediaScraper(NpgsqlConnection connection, HttpClient ht
         // Wikidata sitelinks keyed by site name (e.g. "enwiki", "dawiki")
         public Dictionary<string, WdSitelink> Sitelinks { get; set; } = [];
     }
+}
+
+/// <summary>
+/// Scraped data for a single (species, language) pair.
+/// A null WikipediaTitle means no Wikipedia article was found for this language.
+/// </summary>
+public class WikiSpeciesRow(string lang)
+{
+    public string Lang { get; } = lang;
+    public string? WikipediaTitle { get; init; }
+    public string? WikipediaPageUrl { get; init; }
+    public int? WikipediaPageId { get; init; }
+    public string? WikidataId { get; init; }
+    public string? Description { get; init; }
+    public string? Extract { get; init; }
+    public string? CommonName { get; init; }
+    public bool? Edible { get; init; }
+    public string? HardinessZones { get; init; }
+    public string? ConservationStatus { get; init; }
+    public string? TaxonRank { get; init; }
+    public string? GbifTaxonId { get; init; }
+    public string? ParentTaxonName { get; init; }
+    public string? ParentTaxonWikidataId { get; init; }
 }

--- a/app/Stikl.Web/Model/Species.cs
+++ b/app/Stikl.Web/Model/Species.cs
@@ -5,5 +5,7 @@ public record Species(
     string CommonName,
     string ScientificName,
     string? Family,
-    string? Genus
+    string? Genus,
+    string? WikiPageUrl,
+    string? WikiDescription
 );

--- a/app/Stikl.Web/Program.cs
+++ b/app/Stikl.Web/Program.cs
@@ -97,6 +97,18 @@ if (EnvironmentVariable.GetBool("SCRAPE") ?? false)
     return;
 }
 
+if (EnvironmentVariable.GetBool("WIKI_SCRAPE") ?? false)
+{
+    var db = app.Services.GetRequiredService<NpgsqlDataSource>();
+    var httpClient = app.Services.GetRequiredService<IHttpClientFactory>().CreateClient();
+    httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Stikl/1.0 (plant-sharing app)");
+
+    await using var connection = await db.OpenConnectionAsync();
+    var scraper = new WikipediaScraper(connection, httpClient, Log.Logger);
+    await scraper.Scrape();
+    return;
+}
+
 // TODO: error middleware!
 // TODO: also surface csrf errors!
 app.UseAntiforgery();

--- a/app/Stikl.Web/Routes/PlantRouter.cs
+++ b/app/Stikl.Web/Routes/PlantRouter.cs
@@ -220,14 +220,17 @@ public static class PlantRouter
     {
         using var command = new NpgsqlCommand(
             @"
-SELECT 
-  perenual_id,
-  common_name,
-  scientific_name,
-  family,
-  genus
-FROM perenual_species
-WHERE perenual_id = $1
+SELECT
+  p.perenual_id,
+  p.common_name,
+  p.scientific_name,
+  p.family,
+  p.genus,
+  w.wikipedia_page_url,
+  w.description
+FROM perenual_species p
+LEFT JOIN wiki_species_info w ON p.perenual_id = w.perenual_id AND w.lang = 'en'
+WHERE p.perenual_id = $1
 ",
             connection
         )
@@ -242,7 +245,9 @@ WHERE perenual_id = $1
                     CommonName: reader.GetFieldValue<string>(1),
                     ScientificName: string.Join(" ", reader.GetFieldValue<string[]>(2)),
                     Family: reader.GetStringOrNull(3),
-                    Genus: reader.GetStringOrNull(4)
+                    Genus: reader.GetStringOrNull(4),
+                    WikiPageUrl: reader.GetStringOrNull(5),
+                    WikiDescription: reader.GetStringOrNull(6)
                 ),
                 cancellationToken
             )
@@ -261,7 +266,10 @@ WHERE perenual_id = $1
             has: viewer?.DoesHas(species.Id) is true,
             id: species.Id,
             url: url,
-            WikiLink: "https://en.wikipedia.org/wiki/" + (species.ScientificName.Replace(" ", "_"))
+            WikiLink: species.WikiPageUrl ?? "",
+            hasWikiLink: species.WikiPageUrl is not null,
+            description: species.WikiDescription ?? "",
+            hasDescription: species.WikiDescription is not null
         );
     }
 }

--- a/app/Stikl.Web/Routes/PlantSearcher.cs
+++ b/app/Stikl.Web/Routes/PlantSearcher.cs
@@ -17,15 +17,18 @@ public class PlantSearcher(NpgsqlDataSource db)
 
         using var command = new NpgsqlCommand(
             @"
-SELECT 
-  perenual_id,
-  common_name,
-  scientific_name,
-  family,
-  genus
-FROM perenual_species
-WHERE ts_rank_cd(search_vector, websearch_to_tsquery('english', $1)) > 0
-ORDER BY ts_rank_cd(search_vector, websearch_to_tsquery('english', $1)) DESC
+SELECT
+  p.perenual_id,
+  p.common_name,
+  p.scientific_name,
+  p.family,
+  p.genus,
+  w.wikipedia_page_url,
+  w.description
+FROM perenual_species p
+LEFT JOIN wiki_species_info w ON p.perenual_id = w.perenual_id AND w.lang = 'en'
+WHERE ts_rank_cd(p.search_vector, websearch_to_tsquery('english', $1)) > 0
+ORDER BY ts_rank_cd(p.search_vector, websearch_to_tsquery('english', $1)) DESC
 LIMIT 30
 ",
             connection
@@ -41,7 +44,9 @@ LIMIT 30
                     CommonName: reader.GetFieldValue<string>(1),
                     ScientificName: string.Join(" ", reader.GetFieldValue<string[]>(2)),
                     Family: reader.GetStringOrNull(3),
-                    Genus: reader.GetStringOrNull(4)
+                    Genus: reader.GetStringOrNull(4),
+                    WikiPageUrl: reader.GetStringOrNull(5),
+                    WikiDescription: reader.GetStringOrNull(6)
                 ),
                 cancellationToken
             )

--- a/app/Stikl.Web/Templates/Components/PlantCard.html
+++ b/app/Stikl.Web/Templates/Components/PlantCard.html
@@ -12,10 +12,6 @@
   </ul>
   <h4>{{commonName}}</h4>
   <p class="ScientificName">{{scientificName}}</p>
-  <p>
-    Some info to be announced
-  </p>
-  <a class="Wiki" href="{{WikiLink}}">
-    Wikipedia
-  </a>
+  {% if hasDescription %}<p class="Description">{{description}}</p>{% end %}
+  {% if hasWikiLink %}<a class="Wiki" href="{{WikiLink}}">Wikipedia</a>{% end %}
 </section>

--- a/app/Stikl.Web/Templates/Components/PlantCard.html
+++ b/app/Stikl.Web/Templates/Components/PlantCard.html
@@ -12,6 +12,6 @@
   </ul>
   <h4>{{commonName}}</h4>
   <p class="ScientificName">{{scientificName}}</p>
-  {% if hasDescription %}<p class="Description">{{description}}</p>{% end %}
+  {% if hasDescription %}<p>{{description}}</p>{% end %}
   {% if hasWikiLink %}<a class="Wiki" href="{{WikiLink}}">Wikipedia</a>{% end %}
 </section>

--- a/app/sql/wiki_species_info.sql
+++ b/app/sql/wiki_species_info.sql
@@ -1,0 +1,14 @@
+CREATE TABLE wiki_species_info (
+  perenual_id              INTEGER PRIMARY KEY NOT NULL REFERENCES perenual_species(perenual_id),
+  wikipedia_title          TEXT NULL,
+  wikipedia_page_id        INTEGER NULL,
+  wikidata_id              TEXT NULL,
+  description              TEXT NULL,
+  extract                  TEXT NULL,
+  edible                   BOOLEAN NULL,
+  hardiness_zones          TEXT NULL,
+  conservation_status      TEXT NULL,
+  parent_taxon_name        TEXT NULL,
+  parent_taxon_wikidata_id TEXT NULL,
+  scraped_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);

--- a/app/sql/wiki_species_info.sql
+++ b/app/sql/wiki_species_info.sql
@@ -1,14 +1,31 @@
+-- One row per (species, language). Language-agnostic Wikidata fields (edible,
+-- conservation_status, taxon_rank, gbif_taxon_id, parent_taxon_*) are stored
+-- redundantly in every language row for simplicity.
 CREATE TABLE wiki_species_info (
-  perenual_id              INTEGER PRIMARY KEY NOT NULL REFERENCES perenual_species(perenual_id),
+  perenual_id              INTEGER NOT NULL REFERENCES perenual_species(perenual_id),
+  lang                     TEXT NOT NULL,           -- ISO 639-1: 'en', 'da', …
+
+  -- Wikipedia (language-specific)
   wikipedia_title          TEXT NULL,
+  wikipedia_page_url       TEXT NULL,               -- human-readable URL
   wikipedia_page_id        INTEGER NULL,
-  wikidata_id              TEXT NULL,
-  description              TEXT NULL,
-  extract                  TEXT NULL,
-  edible                   BOOLEAN NULL,
-  hardiness_zones          TEXT NULL,
-  conservation_status      TEXT NULL,
-  parent_taxon_name        TEXT NULL,
-  parent_taxon_wikidata_id TEXT NULL,
-  scraped_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  wikidata_id              TEXT NULL,               -- Wikidata Q-ID, e.g. 'Q12345'
+  description              TEXT NULL,               -- Wikipedia short description
+  extract                  TEXT NULL,               -- Wikipedia intro paragraph
+
+  -- Wikidata (language-specific)
+  common_name              TEXT NULL,               -- P1843 taxon common name
+
+  -- Wikidata (language-agnostic)
+  edible                   BOOLEAN NULL,            -- derived from P279/P31 type hierarchy
+  hardiness_zones          TEXT NULL,               -- extracted from article text
+  conservation_status      TEXT NULL,               -- P141 IUCN label
+  taxon_rank               TEXT NULL,               -- P105 e.g. 'species', 'genus'
+  gbif_taxon_id            TEXT NULL,               -- P846
+  parent_taxon_name        TEXT NULL,               -- P171 label
+  parent_taxon_wikidata_id TEXT NULL,               -- P171 Q-ID
+
+  scraped_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (perenual_id, lang)
 );


### PR DESCRIPTION
Creates a new WikipediaScraper that enriches each perenual_species entry
with data from Wikipedia and Wikidata: description, intro extract, edibility
(via Wikidata type hierarchy), USDA hardiness zones (extracted from article
text), IUCN conservation status, and parent taxon for species-tree relations.

Run with: WIKI_SCRAPE=true dotnet run (from app/Stikl.Web)

https://claude.ai/code/session_017rbbjzGkAhH9AX7qyykouT